### PR TITLE
use key parameter

### DIFF
--- a/fancy-settings/source/settings.js
+++ b/fancy-settings/source/settings.js
@@ -51,6 +51,15 @@ window.addEvent("domready", function () {
 	var apiKey = settings.create({
 		"tab": i18n.get("General"),
 		"group": i18n.get("Authentication"),
+		"name": "apiKeyModeHttpBasic",
+		"type": "checkbox",
+		"label": i18n.get("API key mode http basic:"),
+		"afterSave": reloadBackground
+	});
+	
+	var apiKey = settings.create({
+		"tab": i18n.get("General"),
+		"group": i18n.get("Authentication"),
 		"name": "apiKey",
 		"type": "text",
 		"label": i18n.get("API key:"),

--- a/js/background.js
+++ b/js/background.js
@@ -343,17 +343,34 @@ function getJSON(url, onSuccess, onError) {
 			handleError();
 		};
 
-		xhr.open("GET", getRedmineUrl() + url, true);
+		var targetUrl = getRedmineUrl() + url;
+		
+		
+		
+		
 
 		//attach authorization credentials if available
 		if (settings.get('apiKey')) {
-			var apiKeyHash = Base64.encode(settings.get('apiKey') + ':random');
-			xhr.setRequestHeader('Authorization', "Basic " + apiKeyHash);
+			//in some implementation base auth is not working
+			if (settings.get('apiKeyModeHttpBasic')) {
+				console.log('use basic auth');
+				var apiKeyHash = Base64.encode(settings.get('apiKey') + ':random');
+				xhr.setRequestHeader('Authorization', "Basic " + apiKeyHash);
+			}else{
+				console.log('use key');
+				if(targetUrl.indexOf("?") > -1){
+					targetUrl = targetUrl +"&key="+settings.get('apiKey');
+				}else{
+					targetUrl = targetUrl +"?key="+settings.get('apiKey');	
+				}
+			}
 		} else if (settings.get('userLogin') && settings.get('userPassword')) {
 			var loginPasswordHash = Base64.encode(settings.get('userLogin') + ':' + settings.get('userPassword'));
 			xhr.setRequestHeader('Authorization', "Basic " + loginPasswordHash);
 		}
-
+		
+		//console.log("get url:"+targetUrl);
+		xhr.open("GET", targetUrl , true);
 		xhr.send(null);
 	} catch (e) {
 		console.error('Exception: ' + e);


### PR DESCRIPTION
In my current redmine installation (2.5.2) looks like that http basic authentication is not working for api key.
Redmine doc reports that there are three possibilities to pass the api key, I've just added one by passing the key as a parameter in the url (X-Redmine-API-Key don't know if still supported).

Thanks for the nice work of the plugin.
